### PR TITLE
Added cc:notice to the deed template

### DIFF
--- a/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html
+++ b/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html
@@ -86,11 +86,10 @@
     <ul dir="{{ get_ltr_rtl }}" style="{{ is_rtl_align }}"
         class="license-properties">
       {% if conditions['by'] %}
-      <li class="license by"
-          rel="cc:requires"
-          resource="http://creativecommons.org/ns#Attribution">
+      <li class="license by">
           <p>
-            <strong>{% trans %}Attribution{% endtrans %}</strong> &mdash; {% trans %}You must give <a href="#" id="appropriate_credit_popup" class="helpLink">appropriate credit</a>, provide a link to the license, and <a href="#" id="indicate_changes_popup" class="helpLink">indicate if changes were made</a>.  You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.{% endtrans %}
+            <strong>{% trans %}Attribution{% endtrans %}</strong> &mdash; <span rel="cc:requires"
+          resource="http://creativecommons.org/ns#Attribution">{% trans %}You must give <a href="#" id="appropriate_credit_popup" class="helpLink">appropriate credit</a></span>, provide a link to the license, and <span rel="cc:requires" resource="http://creativecommons.org/ns#Notice"><a href="#" id="indicate_changes_popup" class="helpLink">indicate if changes were made</a></span>.  You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.{% endtrans %}
             <span id="by-more-container"></span>
           </p>
 


### PR DESCRIPTION
Antoine Isaac noticed that the rdf of the licenses was out of sync with
the rdfa of the deed pages.

To solve this Antoine and I propose to change the basic template of the
deed pages where we changed the moved the cc:Attribution requirement in
rdfa and added a cc:Notice requirement.

It was necessary to move the cc:Requires cc:Attribution due to the
placement of the cc:Requires cc:Notice tag. If we leave the cc:Requires
cc:Attribution as it was it implied that there was an hierarchy in
these statements, which there isn’t.
