### PR TITLE
Updated homepage caption background color

### DIFF
--- a/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
+++ b/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
@@ -653,8 +653,7 @@ footer #colophon {
 	left:0px;
 	min-height:30px;
 	padding:5px 20px 5px 20px;
-	background:#ccc;
-	background:rgba(0,0,0,.8);
+	background:#393839;
 	color:#fff;
 	border-top:1px solid #000;
 	text-shadow:none;


### PR DESCRIPTION
image was showing through caption because of transparency settings.