### PR TITLE
Page header/banner fix & homepage caption fix

### DIFF
--- a/docroot/wp-content/themes/creativecommons.org/css/bootstrap-1.2.0.css
+++ b/docroot/wp-content/themes/creativecommons.org/css/bootstrap-1.2.0.css
@@ -1103,7 +1103,7 @@ table .headerSortUp.purple, table .headerSortDown.purple {
  * Repeatable UI elements outside the base styles provided from the scaffolding
  * ---------------------------------------------------------------------------- */
 .topbar {
-  height: 40px;
+  height: auto;
   position: fixed;
   top: 0;
   left: 0;

--- a/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
+++ b/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
@@ -656,7 +656,8 @@ footer #colophon {
 	left:0px;
 	min-height:30px;
 	padding:5px 20px 5px 20px;
-	background:#393839;
+	background:#ccc;
+	background:rgba(0,0,0,.8);
 	color:#fff;
 	border-top:1px solid #000;
 	text-shadow:none;

--- a/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
+++ b/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
@@ -656,8 +656,7 @@ footer #colophon {
 	left:0px;
 	min-height:30px;
 	padding:5px 20px 5px 20px;
-	background:#ccc;
-	background:rgba(0,0,0,.8);
+	background:#393839;
 	color:#fff;
 	border-top:1px solid #000;
 	text-shadow:none;

--- a/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
+++ b/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
@@ -403,7 +403,7 @@ a.menu:after, .dropdown-toggle:after {
   margin: 0;
   padding: 32px 0;
   color: #FFFFFF;
-  font-size: 26px !important;
+  font-size: 26px;
   font-weight: normal;
 }
 #top-banner button {
@@ -452,7 +452,7 @@ a.menu:after, .dropdown-toggle:after {
   #top-banner h1, #top-banner button { float: none; }
   #top-banner h1 {
     padding: 15px 0;
-    font-size: 22px !important;
+    font-size: 22px;
     line-height: 26px;
   }
   #top-banner button {
@@ -462,7 +462,7 @@ a.menu:after, .dropdown-toggle:after {
 }
 @media only screen and (max-width: 360px) {
   #top-banner h1 {
-    font-size: 20px !important;
+    font-size: 20px;
     line-height: 24px;
   }
   #top-banner button {

--- a/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
+++ b/docroot/wp-content/themes/creativecommons.org/css/primary.styles.css
@@ -656,8 +656,7 @@ footer #colophon {
 	left:0px;
 	min-height:30px;
 	padding:5px 20px 5px 20px;
-	background:#ccc;
-	background:rgba(0,0,0,.8);
+    background:#393839;
 	color:#fff;
 	border-top:1px solid #000;
 	text-shadow:none;


### PR DESCRIPTION
Main issue is that at some widths (904px in the screenshot below) the top banner was breaking because the font size was not updating correctly.  Also at this width, the nav is wrapping because of the Global Summit link.  That is causing the top bar to be taller than it's specified height and thus covering the top banner. I've fixed that as well.

![creative commons public domain tools - header issues](https://cloud.githubusercontent.com/assets/1672009/8134857/ab780930-1100-11e5-890e-c1dd79efdf82.png)

Finally, a small tweak to the caption background on the homepage so the image doesn't show through.