### PR TITLE
Correct words in footer

### DIFF
--- a/docroot/legalcode/by-nc-nd_4.0_sv.html
+++ b/docroot/legalcode/by-nc-nd_4.0_sv.html
@@ -165,11 +165,11 @@ Creative Commons kan kontaktas på <a href="//creativecommons.org/">creativecomm
 <a href="//creativecommons.org/licenses/by-nc-nd/4.0/legalcode.mi">te reo Māori</a>, <a href="//creativecommons.org/licenses/by-nc-nd/4.0/legalcode.uk">українська</a>,
 <a href="//creativecommons.org/licenses/by-nc-nd/4.0/legalcode.ja">日本語</a>.
 
-Övriga tillgängliga språk: se <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.</p>
+Vänligen läs <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/licenses/by-nc-nd/4.0/deed.sv">« Tillbaka till den juridiska överssiktssidan.</a></p>
+<p id="footer"><a href="//creativecommons.org/licenses/by-nc-nd/4.0/deed.sv">« Tillbaka till den juridiska översiktssidan.</a></p>
 </div>
 </div>
 </body>

--- a/docroot/legalcode/by-nc-sa_4.0_sv.html
+++ b/docroot/legalcode/by-nc-sa_4.0_sv.html
@@ -176,11 +176,11 @@ Creative Commons kan kontaktas på <a href="//creativecommons.org/">creativecomm
 <a href="//creativecommons.org/licenses/by-nc-sa/4.0/legalcode.mi">te reo Māori</a>, <a href=
 "//creativecommons.org/licenses/by-nc-sa/4.0/legalcode.uk">українська</a>, <a href="//creativecommons.org/licenses/by-nc-sa/4.0/legalcode.ja">日本語</a>.
 
-Övriga tillgängliga språk: se <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.</p>
+Vänligen läs <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/licenses/by-nc-sa/4.0/deed.sv">« Tillbaka till den juridiska överssiktssidan.</a></p>
+<p id="footer"><a href="//creativecommons.org/licenses/by-nc-sa/4.0/deed.sv">« Tillbaka till den juridiska översiktssidan.</a></p>
 </div>
 </div>
 </body>

--- a/docroot/legalcode/by-nc_4.0_sv.html
+++ b/docroot/legalcode/by-nc_4.0_sv.html
@@ -165,11 +165,11 @@ Creative Commons kan kontaktas på <a href="//creativecommons.org/">creativecomm
 <a href="//creativecommons.org/licenses/by-nc/4.0/legalcode.no">norsk</a>, <a href="//creativecommons.org/licenses/by-nc/4.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/licenses/by-nc/4.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/licenses/by-nc/4.0/legalcode.mi">te reo Māori</a>, <a href="//creativecommons.org/licenses/by-nc/4.0/legalcode.uk">українська</a>,
 <a href="//creativecommons.org/licenses/by-nc/4.0/legalcode.ja">日本語</a>.
 
-Övriga tillgängliga språk: se <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.</p>
+Vänligen läs <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/licenses/by-nc/4.0/deed.sv">« Tillbaka till den juridiska överssiktssidan.</a></p>
+<p id="footer"><a href="//creativecommons.org/licenses/by-nc/4.0/deed.sv">« Tillbaka till den juridiska översiktssidan.</a></p>
 </div>
 </div>
 </body>

--- a/docroot/legalcode/by-nd_4.0_sv.html
+++ b/docroot/legalcode/by-nd_4.0_sv.html
@@ -164,11 +164,11 @@ Creative Commons kan kontaktas på <a href="//creativecommons.org/">creativecomm
 <a href="//creativecommons.org/licenses/by-nd/4.0/legalcode.mi">te reo Māori</a>, <a href="//creativecommons.org/licenses/by-nd/4.0/legalcode.uk">українська</a>,
 <a href="//creativecommons.org/licenses/by-nd/4.0/legalcode.ja">日本語</a>.
 
-Övriga tillgängliga språk: se <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.</p>
+Vänligen läs <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/licenses/by-nd/4.0/deed.sv">« Tillbaka till den juridiska överssiktssidan.</a></p>
+<p id="footer"><a href="//creativecommons.org/licenses/by-nd/4.0/deed.sv">« Tillbaka till den juridiska översiktssidan.</a></p>
 </div>
 </div>
 </body>

--- a/docroot/legalcode/by-sa_4.0_sv.html
+++ b/docroot/legalcode/by-sa_4.0_sv.html
@@ -176,11 +176,11 @@ Creative Commons kan kontaktas på <a href="//creativecommons.org/">creativecomm
 "//creativecommons.org/licenses/by-sa/4.0/legalcode.nl">Nederlands</a>, <a href=
 "//creativecommons.org/licenses/by-sa/4.0/legalcode.no">norsk</a>, <a href="//creativecommons.org/licenses/by-sa/4.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/licenses/by-sa/4.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/licenses/by-sa/4.0/legalcode.mi">te reo Māori</a>, <a href="//creativecommons.org/licenses/by-sa/4.0/legalcode.uk">українська</a>, <a href="//creativecommons.org/licenses/by-sa/4.0/legalcode.ja">日本語</a>.
 
-Övriga tillgängliga språk: se <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.</p>
+Vänligen läs <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/licenses/by-sa/4.0/deed.sv">« Tillbaka till den juridiska överssiktssidan.</a></p>
+<p id="footer"><a href="//creativecommons.org/licenses/by-sa/4.0/deed.sv">« Tillbaka till den juridiska översiktssidan.</a></p>
 </div>
 </div>
 </body>

--- a/docroot/legalcode/by_4.0_sv.html
+++ b/docroot/legalcode/by_4.0_sv.html
@@ -163,11 +163,11 @@ Creative Commons kan kontaktas på <a href="//creativecommons.org/">creativecomm
 <a href="//creativecommons.org/licenses/by/4.0/legalcode.mi">te reo Māori</a>, <a href="//creativecommons.org/licenses/by/4.0/legalcode.uk">українська</a>,
 <a href="//creativecommons.org/licenses/by/4.0/legalcode.ja">日本語</a>.
 
-Övriga tillgängliga språk: se <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
+Vänligen läs <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ </a> för mer information om officiella översättningar.</p>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/licenses/by/4.0/deed.sv">« Tillbaka till den juridiska överssiktssidan.</a></p>
+<p id="footer"><a href="//creativecommons.org/licenses/by/4.0/deed.sv">« Tillbaka till den juridiska översiktssidan.</a></p>
 </div>
 </div>
 </body>


### PR DESCRIPTION
Correct the phrase for the FAQ link and “översiktssidan” in the footer. The changes don’t affect the legal code translation.