### PR TITLE
Cc0 cn legalcode

### DIFF
--- a/docroot/legalcode/zero_1.0_cn.html
+++ b/docroot/legalcode/zero_1.0_cn.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>知识共享（Creative Commons）法律文本</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<link rel="stylesheet" type="text/css" href="//creativecommons.org/includes/deed3.css" media="screen"/>
+<link rel="stylesheet" type="text/css" href="//creativecommons.org/includes/deed3-print.css" media="print"/>
+<!--[if lt IE 7]><link rel="stylesheet" type="text/css" href="https://creativecommons.org/includes/deed3-ie.css" media="screen" /><![endif]-->
+<script type="text/javascript" src="//creativecommons.org/includes/errata.js"></script>
+</head>
+<body>
+<p align="center" id="header"><a href="//creativecommons.org/">Creative Commons</a></p>
+<div id="deed" class="green">
+<div id="deed-head">
+<div id="cc-logo">
+<img src="//creativecommons.org/images/deed/cc-logo.jpg" alt=""/>
+</div>
+<h1><span>知识共享（Creative Commons）法律文本</span></h1>
+<div id="deed-license">
+<h2>CC0 1.0 通用</h2>
+</div>
+</div>
+<div id="deed-main">
+<div id="deed-main-content">
+<img src="//creativecommons.org/images/international/unported.png" alt="">
+<div id="deed-disclaimer">
+<div class="summary">
+此法律工具有 <a href="#languages">其他语言</a> 的正式翻译版本。
+</div>
+</div>
+<blockquote>
+CREATIVE COMMONS不是一家律师事务所，也不对外提供法律服务。提供本文件并不导致“律师—当事人”关系的建立。CREATIVE COMMONS按其现状（As Is）提供这些信息。CREATIVE COMMONS对于使用本文件，或者使用依本文件而提供的信息或作品，不提供任何担保，也不对因使用本文件，或者使用依本文件而提供的信息或作品而造成的损失承担损害赔偿责任。
+</blockquote>
+<h3><em>目的声明</em></h3>
+<p>
+全球大多数司法管辖区的法律，都自动将专属的著作权及相关权利（定义如下）授予原始作品或数据库（分别称为“作品”）的原始创作者及后续权利人（个别及统称为“权利人”）。
+</p>
+<p>某些权利人愿意永久地放弃其著作权，以便将其贡献到创意、文化及科学作品的共享领域（“共享领域”）。在此共享领域中，公众能够安心地、无惧未来侵权主张地、并以最大可能的自由形式或为任何目的（包括但不限于商业目的）地以该作品为基础进行创作，修改，汇编，再利用或者再传播该作品。这些权利人之所以放弃著作权并将作品贡献于共享领域，可能是为了推动自由文化的理念或者未来的创意、文化及科学作品的创作，也可能是为了通过他人的使用和投入以赢得声誉和作品更广泛的传播。</p>
+<p>
+声明将CC0适用于某一特定作品的人（“声明人”），为了上述和/或其他的目的和动机，并未预期任何进一步的对价或补偿，在其作为本作品著作权或相关权利权利人的权利范围内，自愿选择将CC0适用于该作品上并公开地依据CC0的条款来传播该作品。声明人理解其对本作品的著作权和相关权利，以及CC0对该权利将产生的意义和法律影响。</p>
+<p><strong>1. 著作权及相关权利。</strong>
+CC0项下的作品可能受到著作权或者相关权利的保护。著作权和相关权利包括但不限于下列权利：
+</p>
+<ol type="i">
+<li>复制、演绎、传播、表演、展示和翻译该作品的权利；</li>
+<li> 原始作者和/或表演者所保留的著作人身权；</li>
+<li>与该作品所描绘的人物形象有关的形象权或隐私权；</li>
+<li>在以下第4条(a)款限制下，保护本作品免受不正当竞争的权利；</li>
+<li>保护该作品中数据的摘录、传播、使用和再使用的权利；</li>
+<li>数据库权利（例如欧洲议会及理事会在1996年3月11日通过的《欧共体数据库法律保护指令》(96/9/EC) 所规定的权利及任何国家在实施该指令过程中产生的权利，包括对该指令的任何修改或后续版本）； 以及</li>
+<li>全球范围内基于相关法律或条约，及任何国家对该法律或条约的实施所产生的相似的、相等同的或一致的权利。</li>
+</ol>
+<p><strong>2. 权利放弃。</strong> 在法律允许的最大范围内，并且在不违反任何相关法律的情况下， 声明人在此公开地、完全地、永久地、不可撤销地并且无条件地放弃和让渡其对本作品的所有著作权、相关权利及任何相关的已知或未知的（包括现存的和未来的）权利主张或诉讼请求（“权利放弃”）。该权利放弃 (i)适用于全球范围； (ii) 适用于相关法律及条约规定的最长存续期间（包括未来的延长期间）； (iii) 适用于任何现存的或未来的媒介，及任意数量的复制件；并且 (iv) 使用者对该作品的使用可以是为任何目的，包括但不限于商业、广告和促销的目的。声明人放弃权利，是为了社会公众每一个成员的利益，且会损害其继承人的利益，声明人完全了解并希望该权利放弃不会被撤回、撤销、取消、终止，或者成为其他任何影响公众按照上述目的声明使用该作品的法律措施或适当措施适用的对象。
+</p>
+<p><strong>3. 转变为公众许可。</strong> 若因为任何原因，上述权利放弃的任何部分依据可适用法律被认定为无效或未生效，该权利放弃应当在考虑声明人上述目的声明的情况下在法律允许的范围内最大程度得以保留。此外，在这种情况下，声明人在此授予每一位受影响的使用者免费的、不可转让的、不可再许可的、非独占性的，不可撤销的及无条件的许可以行使宣告者对该作品的著作权和相关权利（“许可”）。该许可 (i) 适用于全球范围； (ii) 适用于相关法律及条约规定的最长存续期间（包括未来的延长期间）； (iii) 适用于任何现存的或未来的媒介，及任意数量的复制件；并且(iv) 使用者对该作品的使用可以是为任何目的，包括但不限于商业、广告和促销的目的。该许可应被视为自声明人将CC0适用于本作品之日起生效。若因为任何原因使该许可的任一部分在相关法律下被认定为无效或者未生效， 该部分不会使许可的其他部分无效。且在这种情况下，声明人声明他将不会与目的声明相悖而采取下述行动： (i) 行使其保留的任何与该作品有关的著作权和相关权利；或(ii) 提起任何与该作品相关的权利主张或诉讼请求。</p>
+<p><strong>4. 限制及免责条款。</strong></p>
+<ol type="a">
+<li>本声明不涉及声明人所拥有的商标权或专利权，上述权利不会因本声明被放弃、让渡、授权或者受到其它影响。</li>
+<li>声明人按其现状提供本作品，并且，在可适用法律允许的最大范围内，不提供与本作品相关的任何声明或保证，无论明示、默示、或是否为法律所规定，包括但不限于关于本作品权利之担保，可商业性、是否符合某特定目的、未侵害他人权利、不具有潜在或其它缺陷、准确性、或存在或不存在任何不论能否被发现之错误。</li>
+<li>声明人没有责任排除他人可能对本作品或者对本作品的任何使用所主张的权利，包括但不限于任何人对本作品享有的著作权及相关权利。声明人也没有责任为使用本作品获取所需的任何同意、许可或其他权利。</li>
+<li>声明人理解并认可CREATIVE COMMONS并非本文件之当事人，对于CC0或本作品的使用也没有任何责任或义务。</li>
+</ol>
+<blockquote><a name="languages">另外的语言版本</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>。请参阅 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 获得更多关于正式翻译版本的信息。</blockquote>
+</div>
+</div>
+<div id="deed-foot">
+<p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/">« 返回普通文本</a></p>
+</div>
+</div>
+
+
+</body></html>

--- a/docroot/legalcode/zero_1.0_cn.html
+++ b/docroot/legalcode/zero_1.0_cn.html
@@ -66,7 +66,7 @@ CC0项下的作品可能受到著作权或者相关权利的保护。著作权�
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/deed.cn">« 返回普通文本</a></p>
+<p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/deed.zh-Hans">« 返回普通文本</a></p>
 </div>
 </div>
 </body></html>

--- a/docroot/legalcode/zero_1.0_cn.html
+++ b/docroot/legalcode/zero_1.0_cn.html
@@ -23,7 +23,7 @@
 </div>
 <div id="deed-main">
 <div id="deed-main-content">
-<img src="//creativecommons.org/images/international/unported.png" alt="">
+<img src="//creativecommons.org/images/international/unported.png" alt="" />
 <div id="deed-disclaimer">
 <div class="summary">
 此法律工具有 <a href="#languages">其他语言</a> 的正式翻译版本。
@@ -61,11 +61,11 @@ CC0项下的作品可能受到著作权或者相关权利的保护。著作权�
 <li>声明人没有责任排除他人可能对本作品或者对本作品的任何使用所主张的权利，包括但不限于任何人对本作品享有的著作权及相关权利。声明人也没有责任为使用本作品获取所需的任何同意、许可或其他权利。</li>
 <li>声明人理解并认可CREATIVE COMMONS并非本文件之当事人，对于CC0或本作品的使用也没有任何责任或义务。</li>
 </ol>
-<blockquote><a name="languages">另外的语言版本</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>。请参阅 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 获得更多关于正式翻译版本的信息。</blockquote>
+<blockquote><a name="languages">另外的语言版本</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>。请参阅 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 获得更多关于正式翻译版本的信息。</blockquote>
 </div>
 </div>
 <div id="deed-foot">
-<p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/">« 返回普通文本</a></p>
+<p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/deed.cn">« 返回普通文本</a></p>
 </div>
 </div>
 

--- a/docroot/legalcode/zero_1.0_cn.html
+++ b/docroot/legalcode/zero_1.0_cn.html
@@ -23,10 +23,10 @@
 </div>
 <div id="deed-main">
 <div id="deed-main-content">
-<img src="//creativecommons.org/images/international/unported.png" alt="" />
+<img src="//creativecommons.org/images/international/unported.png" alt="">
 <div id="deed-disclaimer">
 <div class="summary">
-此法律工具有 <a href="#languages">其他语言</a> 的正式翻译版本。
+此法律工具有 <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode#languages">其他语言</a>的正式翻译版本。
 </div>
 </div>
 <blockquote>
@@ -34,40 +34,39 @@ CREATIVE COMMONS不是一家律师事务所，也不对外提供法律服务。�
 </blockquote>
 <h3><em>目的声明</em></h3>
 <p>
-全球大多数司法管辖区的法律，都自动将专属的著作权及相关权利（定义如下）授予原始作品或数据库（分别称为“作品”）的原始创作者及后续权利人（个别及统称为“权利人”）。
+全球大多数司法管辖区的法律，都自动将专属的著作权及相关权利（定义如下）授予原始作品或数据库（本文件中都称为“作品”）的原始创作者及后续权利人（个别及统称为“权利人”）。
 </p>
-<p>某些权利人愿意永久地放弃其著作权，以便将其贡献到创意、文化及科学作品的共享领域（“共享领域”）。在此共享领域中，公众能够安心地、无惧未来侵权主张地、并以最大可能的自由形式或为任何目的（包括但不限于商业目的）地以该作品为基础进行创作，修改，汇编，再利用或者再传播该作品。这些权利人之所以放弃著作权并将作品贡献于共享领域，可能是为了推动自由文化的理念或者未来的创意、文化及科学作品的创作，也可能是为了通过他人的使用和投入以赢得声誉和作品更广泛的传播。</p>
+<p>某些权利人愿意永久地放弃其著作权，以便将其贡献到创意、文化及科学作品的共享领域（“共享领域”）。在此共享领域中，公众能够安心地、无惧未来侵权主张地、并以最大可能的自由形式或为任何目的（包括但不限于商业目的）地以该作品为基础进行创作、修改、汇编、再利用或者再传播该作品。这些权利人之所以放弃著作权并将作品贡献于共享领域，可能是为了推动自由文化的理念或者未来的创意、文化及科学作品的创作，也可能是为了通过他人的使用和投入以赢得声誉和作品更广泛的传播。</p>
 <p>
-声明将CC0适用于某一特定作品的人（“声明人”），为了上述和/或其他的目的和动机，并未预期任何进一步的对价或补偿，在其作为本作品著作权或相关权利权利人的权利范围内，自愿选择将CC0适用于该作品上并公开地依据CC0的条款来传播该作品。声明人理解其对本作品的著作权和相关权利，以及CC0对该权利将产生的意义和法律影响。</p>
+声明将CC0适用于某一特定作品的人（“声明人”），为了上述或者其他的目的和动机，并未预期任何进一步的对价或补偿，在其作为本作品著作权或相关权利权利人的权利范围内，自愿选择将CC0适用于该作品上并公开地依据CC0的条款来传播该作品。声明人理解其对本作品的著作权和相关权利，以及CC0对该权利将产生的意义和法律影响。</p>
 <p><strong>1. 著作权及相关权利。</strong>
 CC0项下的作品可能受到著作权或者相关权利的保护。著作权和相关权利包括但不限于下列权利：
 </p>
 <ol type="i">
 <li>复制、演绎、传播、表演、展示和翻译该作品的权利；</li>
-<li> 原始作者和/或表演者所保留的著作人身权；</li>
+<li> 原始作者或者表演者所保留的著作人身权；
+</li>
 <li>与该作品所描绘的人物形象有关的形象权或隐私权；</li>
 <li>在以下第4条(a)款限制下，保护本作品免受不正当竞争的权利；</li>
 <li>保护该作品中数据的摘录、传播、使用和再使用的权利；</li>
-<li>数据库权利（例如欧洲议会及理事会在1996年3月11日通过的《欧共体数据库法律保护指令》(96/9/EC) 所规定的权利及任何国家在实施该指令过程中产生的权利，包括对该指令的任何修改或后续版本）； 以及</li>
-<li>全球范围内基于相关法律或条约，及任何国家对该法律或条约的实施所产生的相似的、相等同的或一致的权利。</li>
+<li>数据库权利（例如欧洲议会及理事会在1996年3月11日通过的《欧共体数据库法律保护指令》(96/9/EC) （包括对该指令的任何修改或后续版本）所规定的权利，及任何国家在实施该指令过程中产生的权利）； 以及</li>
+<li>全球范围内基于相关法律或条约及任何国家对该法律或条约的实施所产生的相似的、相等同的或一致的权利。</li>
 </ol>
 <p><strong>2. 权利放弃。</strong> 在法律允许的最大范围内，并且在不违反任何相关法律的情况下， 声明人在此公开地、完全地、永久地、不可撤销地并且无条件地放弃和让渡其对本作品的所有著作权、相关权利及任何相关的已知或未知的（包括现存的和未来的）权利主张或诉讼请求（“权利放弃”）。该权利放弃 (i)适用于全球范围； (ii) 适用于相关法律及条约规定的最长存续期间（包括未来的延长期间）； (iii) 适用于任何现存的或未来的媒介，及任意数量的复制件；并且 (iv) 使用者对该作品的使用可以是为任何目的，包括但不限于商业、广告和促销的目的。声明人放弃权利，是为了社会公众每一个成员的利益，且会损害其继承人的利益，声明人完全了解并希望该权利放弃不会被撤回、撤销、取消、终止，或者成为其他任何影响公众按照上述目的声明使用该作品的法律措施或适当措施适用的对象。
 </p>
-<p><strong>3. 转变为公众许可。</strong> 若因为任何原因，上述权利放弃的任何部分依据可适用法律被认定为无效或未生效，该权利放弃应当在考虑声明人上述目的声明的情况下在法律允许的范围内最大程度得以保留。此外，在这种情况下，声明人在此授予每一位受影响的使用者免费的、不可转让的、不可再许可的、非独占性的，不可撤销的及无条件的许可以行使宣告者对该作品的著作权和相关权利（“许可”）。该许可 (i) 适用于全球范围； (ii) 适用于相关法律及条约规定的最长存续期间（包括未来的延长期间）； (iii) 适用于任何现存的或未来的媒介，及任意数量的复制件；并且(iv) 使用者对该作品的使用可以是为任何目的，包括但不限于商业、广告和促销的目的。该许可应被视为自声明人将CC0适用于本作品之日起生效。若因为任何原因使该许可的任一部分在相关法律下被认定为无效或者未生效， 该部分不会使许可的其他部分无效。且在这种情况下，声明人声明他将不会与目的声明相悖而采取下述行动： (i) 行使其保留的任何与该作品有关的著作权和相关权利；或(ii) 提起任何与该作品相关的权利主张或诉讼请求。</p>
+<p><strong>3. 转变为公众许可。</strong> 若因为任何原因，上述权利放弃的任何部分依据可适用法律被认定为无效或未生效，该权利放弃应当在考虑声明人上述目的声明的情况下在法律允许的范围内最大程度得以保留。此外，在这种情况下，声明人在此授予每一位受影响的使用者免费的、不可转让的、不可再许可的、非独占性的、不可撤销的及无条件的许可以行使声明人对该作品的著作权和相关权利（“许可”）。该许可 (i) 适用于全球范围； (ii) 适用于相关法律及条约规定的最长存续期间（包括未来的延长期间）； (iii) 适用于任何现存的或未来的媒介，及任意数量的复制件；并且(iv) 使用者对该作品的使用可以是为任何目的，包括但不限于商业、广告和促销的目的。该许可应被视为自声明人将CC0适用于本作品之日起生效。若因为任何原因使该许可的任一部分在相关法律下被认定为无效或者未生效， 该部分不会使许可的其他部分无效。且在这种情况下，声明人声明他将不会与目的声明相悖而采取下述行动： (i) 行使其保留的任何与该作品有关的著作权和相关权利；或(ii) 提起任何与该作品相关的权利主张或诉讼请求。</p>
 <p><strong>4. 限制及免责条款。</strong></p>
 <ol type="a">
-<li>本声明不涉及声明人所拥有的商标权或专利权，上述权利不会因本声明被放弃、让渡、授权或者受到其它影响。</li>
-<li>声明人按其现状提供本作品，并且，在可适用法律允许的最大范围内，不提供与本作品相关的任何声明或保证，无论明示、默示、或是否为法律所规定，包括但不限于关于本作品权利之担保，可商业性、是否符合某特定目的、未侵害他人权利、不具有潜在或其它缺陷、准确性、或存在或不存在任何不论能否被发现之错误。</li>
+<li>本声明不涉及声明人所拥有的商标权或专利权，上述权利不会因本声明而被放弃、让渡、授权或者受到其它影响。</li>
+<li>声明人按其现状提供本作品，并且，在可适用法律允许的最大范围内，不提供与本作品相关的任何声明或保证，无论明示、默示或是否为法律所规定，包括但不限于关于本作品权利之担保、可商业性、是否符合某特定目的、未侵害他人权利、不具有潜在或其它缺陷、准确性、或者存在或不存在任何不论能否被发现之错误。</li>
 <li>声明人没有责任排除他人可能对本作品或者对本作品的任何使用所主张的权利，包括但不限于任何人对本作品享有的著作权及相关权利。声明人也没有责任为使用本作品获取所需的任何同意、许可或其他权利。</li>
 <li>声明人理解并认可CREATIVE COMMONS并非本文件之当事人，对于CC0或本作品的使用也没有任何责任或义务。</li>
 </ol>
-<blockquote><a name="languages">另外的语言版本</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>。请参阅 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 获得更多关于正式翻译版本的信息。</blockquote>
+<blockquote><a name="languages">另外的语言版本</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>。请参阅 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a>获得更多关于正式翻译版本的信息。</blockquote>
 </div>
 </div>
 <div id="deed-foot">
 <p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/deed.cn">« 返回普通文本</a></p>
 </div>
 </div>
-
-
 </body></html>

--- a/docroot/legalcode/zero_1.0_cn.html
+++ b/docroot/legalcode/zero_1.0_cn.html
@@ -26,7 +26,7 @@
 <img src="//creativecommons.org/images/international/unported.png" alt="">
 <div id="deed-disclaimer">
 <div class="summary">
-此法律工具有 <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode#languages">其他语言</a>的正式翻译版本。
+此法律工具有 <a href="#languages">其他语言</a>的正式翻译版本。
 </div>
 </div>
 <blockquote>


### PR DESCRIPTION
This file contains the Chinese simplified CC0 translation. The final extension should be .zh-Hans instead of .cn. The languages should be listed as 中文 in the footer of all the other translations.