### PR TITLE
Cc0 tw legalcode

### DIFF
--- a/docroot/legalcode/zero_1.0_tw.html
+++ b/docroot/legalcode/zero_1.0_tw.html
@@ -23,7 +23,7 @@
 </div>
 <div id="deed-main">
 <div id="deed-main-content">
-<img src="//creativecommons.org/images/international/unported.png" alt=""/>
+<img src="//creativecommons.org/images/international/unported.png" alt="" />
 <div id="deed-disclaimer">
 <div class="summary">
 此一法律工具的正式翻譯也具有<a href="#languages">其他語言的版本</a>。
@@ -55,7 +55,7 @@ CREATIVE COMMONS 不是法律事務所，亦不提供法律服務。散布本文
 <li>宣告者免責於排除他人可能對本作品或對本作品的任何使用所主張的權利，包含但不限於任何人對本作品的著作權及其相關權利。此外，宣告者亦免責於取得任何必要的同意、允許或其他權利以使用本作品。</li>
 <li>宣告者了解並認知到 Creative Commons 並非本文件之當事人，且對於 CC0 或利用本作品不負任何責任或義務。</li>
 </ol>
-<blockquote><a name="languages">另外的語言版本有</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>. 請參閱
+<blockquote><a name="languages">另外的語言版本有</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>. 請參閱
   <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 來得到更多正式翻譯版本的資訊。</blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_tw.html
+++ b/docroot/legalcode/zero_1.0_tw.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Creative Commons Legal Code</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<link rel="stylesheet" type="text/css" href="//creativecommons.org/includes/deed3.css" media="screen"/>
+<link rel="stylesheet" type="text/css" href="//creativecommons.org/includes/deed3-print.css" media="print"/>
+<!--[if lt IE 7]><link rel="stylesheet" type="text/css" href="https://creativecommons.org/includes/deed3-ie.css" media="screen" /><![endif]-->
+<script type="text/javascript" src="//creativecommons.org/includes/errata.js"></script>
+</head>
+<body>
+<p align="center" id="header"><a href="//creativecommons.org/">Creative Commons</a></p>
+<div id="deed" class="green">
+<div id="deed-head">
+<div id="cc-logo">
+<img src="//creativecommons.org/images/deed/cc-logo.jpg" alt=""/>
+</div>
+<h1><span>Creative Commons Legal Code</span></h1>
+<div id="deed-license">
+<h2>CC0 1.0 通用</h2>
+</div>
+</div>
+<div id="deed-main">
+<div id="deed-main-content">
+<img src="//creativecommons.org/images/international/unported.png" alt=""/>
+<div id="deed-disclaimer">
+<div class="summary">
+此一法律工具的正式翻譯也具有<a href="#languages">其他語言的版本</a>。
+</div>
+</div>
+<blockquote>
+CREATIVE COMMONS 不是法律事務所，亦不提供法律服務。散布本文件並不產生律師和客戶的關係。CREATIVE COMMONS 之資訊乃是就現狀而提供。CREATIVE COMMONS 對於使用本文件、或依本文件所提供的資訊或作品不負保證責任，並免責於因使用本文件、或依本文件所提供的資訊或作品所產生的損害。
+</blockquote>
+<h3><em>目的之聲明</em></h3>
+<p>全球大多數司法管轄領域的法律，自動將專屬的著作權及其相關權利（定義如下）賦予原始創作及/或資料庫（分別稱「作品」）之創作者及之後的權利人（個別及統稱「權利人」）。</p>
+<p>某些權利人想要永久放棄其作品之權利，是為了將它貢獻到一個創意、文化及科學作品之共享領域（「共享領域」）。在該共享領域中，公眾能安心地、無懼未來的侵權主張地、並以最大可能的自由形式及任何目的，包含但不限於商業目的，以該等作品為基礎另為創作、修改、再利用、再散布這些作品及將該等作品收錄於其他作品中。這些權利人，將其作品貢獻到該共享領域中，可能是為了發揚自由文化的理想或進一步促進創意、文化及科學作品的產生、或某種程度上透過他人的使用及努力，來為自己贏得名聲或使其作品被更廣泛地散布。</p>
+<p>為了這些及/或其他目的和動機，且未預期任何額外之對價或補償下，以 CC0 結合一作品之人（「宣告者」），在他是該作品的著作權及其相關權利的權利人的範圍內，且其了解到他對該作品的著作權及其相關權利、及 CC0 對那些權利將產生的意義和法律影響，自願選擇將 CC0 適用在該作品上，且公開地依據 CC0 的條款來散布該作品。</p>
+<p><strong>1.著作權及其相關權利。</strong>一作品依據 CC0 提供利用（本作品），可能受到著作權及其相關或鄰接權利（「著作權及其相關權利」）的保護。著作權及其相關權利，包含但不限於下列權利：</p>
+<ol type="i">
+<li>重製、改作、散布、表演、展示、傳達及翻譯一作品的權利；</li>
+<li>保留予原始作者及/或表演人之著作人格權；</li>
+<li>於一作品中描繪、與某人的形象或肖像有關的形象權或隱私權；</li>
+<li>保護一作品免於受不正競爭的權利，需受到以下第 4(a) 點的限制；</li>
+<li>保護得擷取、散播、利用及再利用一作品中之資料的權利；</li>
+<li>資料庫的權利（例如歐洲議會及理事會在 1996 年 3 月 11 日通過編號 96/9/EC 指令之後對於資料庫的法律保護，及任何國家對此指令的實施所產生的權利，包含任何對該指令的修改或後續版本）；</li>
+<li>其他遍及全球、基於相關法律或條約，及任何國家對該等法律或條約所實施之相似、相等或一致的權利。</li>
+</ol>
+<p><strong>2. 權利之拋棄。</strong>在不悖於相關法律規定，且合於法律允許的最大範圍內，宣告者於此公開地、完全地、永久地、不可撤回地及無條件地拋棄及放棄其對於本作品所有的著作權及其相關權利、及相關聯的權利主張及訴訟請求，不論現在已知或未知，包含現行及未來的權利主張及訴訟請求（「權利之拋棄」）。該權利之拋棄 (i) 適用於全球的領域，(ii) 適用於相關法律及條約規定的最長存續期間（包含未來的延長期間），(iii) 適用於任何現行或未來的媒介及任何數量的重製品上，及 (iv) 使用者得為了任何目的，包含但不限於商業、廣告或促銷之目的利用本作品。宣告者為前述權利之拋棄，是為了有利於公眾中的每一個人，且會損及宣告者之繼承者之利益，宣告者完全了解且希望該權利之拋棄永遠不會被撤回、撤銷、取消、終止或成為任何其他法律或相當行為之適用對象，以使公眾基於前述宣告者明示的目的之聲明，對於本作品能平和的享用，不會受到任何打擾。</p>
+<p><strong>3. 轉換為公眾授權。</strong>若因為任何原因，前述權利之拋棄的任一部分依據相關法律，被認定為無效或不生效力，則該權利之拋棄應在考量到前述宣告者明示的目的之聲明、在相關法律允許的最大範圍內被保留。此外，當前述權利之拋棄被如此認定時，宣告者於此授與每位受影響者免權利金、不得移轉的、不得再授權的、非專屬的、不得撤回的，以及無條件的授權，來實施宣告者對本作品的著作權及其相關權利（「授權」）。該授權 (i) 適用於全球的領域，(ii) 適用於相關法律及條約規定的最長存續期間（包含未來的延長期間），(iii) 適用於任何現行或未來的媒介及任何數量的重製品上，及 (iv) 使用者得為了任何目的，包含但不限於商業、廣告或促銷之目的利用本作品。該授權應被視為溯及自宣告者將 CC0 適用於本作品之日起生效。若因為任何原因使該授權的任一部分在相關法律下被認定為無效或不生效力，該無效或不生效力部份不因而使該授權其餘部分亦無效，且在這個情況下，宣告者於此聲明他將不會 (i)行使任何他對本作品剩餘的著作權及其相關權利或 (ii) 提起任何與本作品相關的權利主張及訴訟請求，在前述 (i)(ii) 任一情形下之聲明並不會與前述宣告者明示的目的之聲明相悖。</p>
+<p><strong>4. 限制及免除責任聲明。</strong></p>
+<ol type="a">
+<li>宣告者所擁有的商標權或專利權，不會因為本文件，而被拋棄、放棄、授權或受到其他影響。</li>
+<li>宣告者是以現狀提供本作品，且未聲明或提供關於本作品之任何保證，無論明示、默示、或是否為法律所規定，包含但不限於任何有關本作品權利之擔保、可商業性、是否符合某特定之目的、未侵害他人權利、不具有潛在或其他之缺陷、正確性、或不論能否被發現之現存或欠缺的錯誤，前述所有內容皆是在相關法律所允許的最大範圍內予以提供。</li>
+<li>宣告者免責於排除他人可能對本作品或對本作品的任何使用所主張的權利，包含但不限於任何人對本作品的著作權及其相關權利。此外，宣告者亦免責於取得任何必要的同意、允許或其他權利以使用本作品。</li>
+<li>宣告者了解並認知到 Creative Commons 並非本文件之當事人，且對於 CC0 或利用本作品不負任何責任或義務。</li>
+</ol>
+<blockquote><a name="languages">另外的語言版本有</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>. 請參閱
+  <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 來得到更多正式翻譯版本的資訊。</blockquote>
+</div>
+</div>
+<div id="deed-foot">
+<p id="footer"><a href="//creativecommons.org/publicdomain/zero/1.0/deed.zh_TW">回到授權標章</a></p>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This file contains the Chinese traditional CC0 translation. The final extension should be .zh-Hant instead of .tw. The languages should be listed as 華語 in the footer of all the other translations.