### PR TITLE
Lint HTML PRs for translations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    machine: true
+      image: circleci/classic:latest
+    steps:
+    - checkout
+    - run: sudo apt-get update && sudo apt-get install -y tidy
+    - run: git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master) | grep .html | tidy -errors -quiet


### PR DESCRIPTION
Fixes https://github.com/creativecommons/tech-support/issues/164

Run `tidy` to check for HTML errors in PRs.