### PR TITLE
Fixes visual bug on deed pages for some NC licenses prior to 4.0

### DIFF
--- a/docroot/includes/jurisdictions.css
+++ b/docroot/includes/jurisdictions.css
@@ -2,47 +2,48 @@
  * This file contains any jurisdiction-specific CSS or overrides.
  */
 
-/* Belgium */
+/* Belgium 
 .be .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
-
-/* Finland */
+*/
+/* Finland 
 .fi .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
-
-/* France */
+*/
+/* France 
 .fr .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
-
-/* Guatemala */
+*/
+/* Guatemala 
 .gt .nc {
 	background: url("/images/deed/nc-gt.png") 0 0 no-repeat;
 }
-
-/* Italy */
+*/
+/* Italy 
 .it .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
-
-/* Japan */
+*/
+/* Japan 
 .jp .nc {
 	background: url("/images/deed/nc-jp.png") 0 0 no-repeat;
 }
-
-/* Luxembourg */
+*/
+/* Luxembourg 
 .lu .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
-
-/* Netherlands */
+*/
+/* Netherlands 
 .nl .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
-
-/* Spain */
+*/
+/* Spain 
 .es .nc {
 	background: url("/images/deed/nc-eu.png") 0 0 no-repeat;
 }
+*/


### PR DESCRIPTION
Temporary fix for #692 

Frankly it is an insult to all these nations to have this visual bug live since the introduction of the redesign.

I'd much more prefer that there was a push for cleaning this up an allowing the EU, Japan, and Guatamala to show their own currency in the NC licenses in the licenses prior to 4.0.

**Description**
Removes all older customised currency icons
