### PR TITLE
updated language footer using new tool

### DIFF
--- a/docroot/legalcode/zero_1.0.html
+++ b/docroot/legalcode/zero_1.0.html
@@ -207,7 +207,25 @@
       obligation with respect to this CC0 or use of the Work.</li>
     </ol>
 <!-- Legalcode End - DO NOT DELETE -->
-    <blockquote><a id="languages"></a>Additional languages available: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Please read the <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> for more information about official translations.</blockquote>
+    <blockquote><a id="languages"></a>Additional languages available: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Please read the <a href="/FAQ#officialtranslations">FAQ</a> for more information about official translations.</blockquote>
       </div>
     </div>
 

--- a/docroot/legalcode/zero_1.0.html
+++ b/docroot/legalcode/zero_1.0.html
@@ -224,7 +224,7 @@
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Please read the <a href="/FAQ#officialtranslations">FAQ</a> for more information about official translations.</blockquote>
       </div>
     </div>

--- a/docroot/legalcode/zero_1.0_el.html
+++ b/docroot/legalcode/zero_1.0_el.html
@@ -80,7 +80,7 @@
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Παρακαλώ διαβάστε το <a href="/FAQ#officialtranslations">FAQ</a> για περαιτέρω πληροφορίες σχετικά με τις επίσημες μεταφράσεις.</blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_el.html
+++ b/docroot/legalcode/zero_1.0_el.html
@@ -63,7 +63,25 @@
 <br />δ. Ο Δηλών κατανοεί και αναγνωρίζει ότι η «Creative Commons» δεν αποτελεί μέρος του παρόντος εγγράφου και δεν υπέχει κανένα καθήκον ή υποχρέωση όσον αφορά την παρούσα CC0 ή τη χρήση του Έργου.
 </p>
 <!-- Legalcode End - DO NOT DELETE -->
-<blockquote><a id="languages"></a>Επιπρόσθετες διαθέσιμες γλώσσες: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Παρακαλώ διαβάστε το <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> για περαιτέρω πληροφορίες σχετικά με τις επίσημες μεταφράσεις.</blockquote>
+<blockquote><a id="languages"></a>Επιπρόσθετες διαθέσιμες γλώσσες: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Παρακαλώ διαβάστε το <a href="/FAQ#officialtranslations">FAQ</a> για περαιτέρω πληροφορίες σχετικά με τις επίσημες μεταφράσεις.</blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_es.html
+++ b/docroot/legalcode/zero_1.0_es.html
@@ -77,7 +77,7 @@ Una Obra disponible bajo una CC0 puede estar protegida por derechos de autor o d
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Por favor lea las <a href="/FAQ#officialtranslations">Preguntas Frecuentes</a> para obtener más información acerca de las traducciones oficiales.</blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_es.html
+++ b/docroot/legalcode/zero_1.0_es.html
@@ -60,7 +60,25 @@ Una Obra disponible bajo una CC0 puede estar protegida por derechos de autor o d
 <li>El Afirmante renuncia a la responsabilidad de los derechos de compensación de otras personas que puedan aplicarse a la Obra o a cualquier uso en esto, incluyendo sin limitación los Derechos de Autor y Derechos Conexos sobre la Obra de cualquier persona. Además, el Afirmante renuncia a la responsabilidad de obtener cualquier consentimiento o permiso necesario, así como cualquier otros derechos requeridos para cualquier uso de la Obra.</li>
 <li>El Afirmante entiende y reconoce que Creative Commons no es una parte en este documento y no tiene ningún derecho u obligación con respecto a esta CC0 o al uso de la Obra.</li>
 </ol>
-<blockquote><a id="languages"></a>Otros idiomas disponibles: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Por favor lea las <a href="//wiki.creativecommons.org/FAQ#officialtranslations">Preguntas Frecuentes</a> para obtener más información acerca de las traducciones oficiales.</blockquote>
+<blockquote><a id="languages"></a>Otros idiomas disponibles: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Por favor lea las <a href="/FAQ#officialtranslations">Preguntas Frecuentes</a> para obtener más información acerca de las traducciones oficiales.</blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_eu.html
+++ b/docroot/legalcode/zero_1.0_eu.html
@@ -77,7 +77,7 @@ CC0-rekin eskuragarri jartzen den Lan batek Egile-eskubideen eta horiei Lotutako
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
 
   Irakurri <a href="/FAQ#officialtranslations">FAQ</a> atala itzulpen ofizialen inguruko informazio gehiago izateko.</blockquote>
 </div>

--- a/docroot/legalcode/zero_1.0_eu.html
+++ b/docroot/legalcode/zero_1.0_eu.html
@@ -60,8 +60,26 @@ CC0-rekin eskuragarri jartzen den Lan batek Egile-eskubideen eta horiei Lotutako
 <li>Aitortzaileak ez du bere gain hartzen, Lanean edo Lanarekin egiten den edozein erabilerari buruz, hirugarrenek izan ditzaketen eskubideak eskuratzeko erantzukizunik, barne hartuz, mugarik gabe, edozein pertsonak Lanaren gainean dituen Egile-eskubideak eta horiei Lotutako Eskubideak. Gainera, Aitortzaileak ez du bere gain hartzen Lana erabiltzeko beharrezkoa den edozein onespen, baimen edo bestelako eskubideren bat lortzeko erantzukizunik.</li>
 <li>Aitortzaileak ulertzen eta onartzen du Creative Commons ez dela dokumentu honen alderdietako bat, eta Creative Commons-ek ez duela inolako betebeharrik CC0 honi eta Lanaren erabilerari dagokienez.</li>
 </ol>
-<blockquote><a id="languages">Eskuragarri dauden beste hizkuntza batzuk</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-  Irakurri <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> atala itzulpen ofizialen inguruko informazio gehiago izateko.</blockquote>
+<blockquote><a id="languages">Eskuragarri dauden beste hizkuntza batzuk</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+
+  Irakurri <a href="/FAQ#officialtranslations">FAQ</a> atala itzulpen ofizialen inguruko informazio gehiago izateko.</blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_fi.html
+++ b/docroot/legalcode/zero_1.0_fi.html
@@ -114,7 +114,7 @@
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Lisätietoa virallisista käännöksistä <a href="/FAQ#officialtranslations">FAQ</a>-sivulla.</blockquote>
       </div>
     </div>

--- a/docroot/legalcode/zero_1.0_fi.html
+++ b/docroot/legalcode/zero_1.0_fi.html
@@ -97,7 +97,25 @@
 
       <li>Vahvistaja ymmärtää ja myöntää, ettei Creative Commons ole tämän asiakirjan osapuoli, eikä sillä ole mitään tehtäviä tai velvollisuuksia CC0:aan tai Teoksen käyttöön liittyen.</li>
     </ol>
-    <blockquote><a id="languages">Saatavilla muilla kielillä</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Lisätietoa virallisista käännöksistä <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a>-sivulla.</blockquote>
+    <blockquote><a id="languages">Saatavilla muilla kielillä</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Lisätietoa virallisista käännöksistä <a href="/FAQ#officialtranslations">FAQ</a>-sivulla.</blockquote>
       </div>
     </div>
 

--- a/docroot/legalcode/zero_1.0_fr.html
+++ b/docroot/legalcode/zero_1.0_fr.html
@@ -181,7 +181,25 @@ ou de l'utilisation de l'Œuvre.</li>
 
     </ol>
 
-<blockquote><a id="languages">Autres langues disponibles</a> : <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Veuillez vous référer à la <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> pour plus d'informations sur les traductions officielles.</blockquote>
+<blockquote><a id="languages">Autres langues disponibles</a> : 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Veuillez vous référer à la <a href="/FAQ#officialtranslations">FAQ</a> pour plus d'informations sur les traductions officielles.</blockquote>
 
 
 

--- a/docroot/legalcode/zero_1.0_fr.html
+++ b/docroot/legalcode/zero_1.0_fr.html
@@ -198,7 +198,7 @@ ou de l'utilisation de l'Œuvre.</li>
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Veuillez vous référer à la <a href="/FAQ#officialtranslations">FAQ</a> pour plus d'informations sur les traductions officielles.</blockquote>
 
 

--- a/docroot/legalcode/zero_1.0_it.html
+++ b/docroot/legalcode/zero_1.0_it.html
@@ -229,7 +229,7 @@
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
 
           Si prega di leggere queste
           <a href="/FAQ#officialtranslations">FAQ</a>

--- a/docroot/legalcode/zero_1.0_it.html
+++ b/docroot/legalcode/zero_1.0_it.html
@@ -212,9 +212,27 @@
         </ol>
         <blockquote>
           <a id="languages">Altre lingue disponibili</a>:
-          <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+          
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+
           Si prega di leggere queste
-          <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a>
+          <a href="/FAQ#officialtranslations">FAQ</a>
           per maggiori informazioni sulle traduzioni ufficiali.
         </blockquote>
       </div>

--- a/docroot/legalcode/zero_1.0_ja.html
+++ b/docroot/legalcode/zero_1.0_ja.html
@@ -86,7 +86,25 @@
 
       <li>確約者は、クリエイティブ・コモンズが本文書の当事者ではなく、このCC0または本作品の利用に関連するいかなる義務または責任を負わないことを理解し、同意する。</li>
     </ol>
-    <blockquote><a id="languages">入手可能なその他の言語</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="http://creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="http://creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="http://creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. 公式翻訳に関する情報は <a href="http://wiki.creativecommons.org/FAQ#What_are_the_official_translations_of_the_CC_licenses.3F">FAQ</a> をご覧ください（英語）。</blockquote>
+    <blockquote><a id="languages">入手可能なその他の言語</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>。
+<!-- Language Footer End --- DO NOT DELETE -->
+ 公式翻訳に関する情報は <a href="/FAQ#officialtranslations">FAQ</a> をご覧ください（英語）。</blockquote>
       </div>
     </div>
 

--- a/docroot/legalcode/zero_1.0_ja.html
+++ b/docroot/legalcode/zero_1.0_ja.html
@@ -103,7 +103,7 @@
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>。
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  公式翻訳に関する情報は <a href="/FAQ#officialtranslations">FAQ</a> をご覧ください（英語）。</blockquote>
       </div>
     </div>

--- a/docroot/legalcode/zero_1.0_ko.html
+++ b/docroot/legalcode/zero_1.0_ko.html
@@ -80,7 +80,7 @@ CC0로 공유되는 창작물은 저작권 및 관련 권리 또는 저작인접
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  공식 번역에 대한 자세한 정보는 <a href="/FAQ#officialtranslations">자주 묻는 질문(FAQ)</a>을 참조하시기 바랍니다.</blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_ko.html
+++ b/docroot/legalcode/zero_1.0_ko.html
@@ -63,7 +63,25 @@ CC0로 공유되는 창작물은 저작권 및 관련 권리 또는 저작인접
 <li>확약자는 크리에이티브 커먼즈는 이 문서의 당사자가 아니며 이 CC0 또는 창작물의 사용과 관련하여 어떠한 의무나 책임도 지지 않음을 이해하고 동의합니다.</li>
 </ol>
 <!-- Legalcode End - DO NOT DELETE -->
-<blockquote><a id="languages"></a>본 문서는 다음 언어로도 이용할 수 있습니다 : <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. 공식 번역에 대한 자세한 정보는 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">자주 묻는 질문(FAQ)</a>을 참조하시기 바랍니다.</blockquote>
+<blockquote><a id="languages"></a>본 문서는 다음 언어로도 이용할 수 있습니다 : 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ 공식 번역에 대한 자세한 정보는 <a href="/FAQ#officialtranslations">자주 묻는 질문(FAQ)</a>을 참조하시기 바랍니다.</blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_lt.html
+++ b/docroot/legalcode/zero_1.0_lt.html
@@ -60,7 +60,25 @@ Pagal CC0 platinamas Kūrinys gali būti saugomas autorių ir gretutinių teisi�
 <li>Pareiškėjas neprisiima atsakomybės dėl kitų asmenų teisių, kurios gali būti taikytinos Kūriniui ar bet kokiam jo panaudojimui, perėmimo, įskaitant, bet neapsiribojant, bet kokių asmenų Autorių ir Gretutinių Teisių į Kūrinį. Taip pat Pareiškėjas neprisiima atsakomybės dėl bet kokių sutikimų, leidimų ar kitų teisių, reikalingų bet kokiam Kūrinio panaudojimui,  gavimo.</li>
 <li>Pareiškėjas supranta ir patvirtina, kad Creative Commons nėra šio dokumento šalimi ir neturi jokios pareigos ar prievolės, susijusios su šiuo CC0 taikymu ar Kūrinio panaudojimu.</li>
 </ol>
-<blockquote><a id="languages">Skaitykite kitomis kalbomis: </a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Prašome skaityti <a href="//wiki.creativecommons.org/FAQ#officialtranslations">Klausimus ir Atsakymus</a>, jei norite gauti daugiau informacijos apie oficialiuosius vertimus. </blockquote>
+<blockquote><a id="languages">Skaitykite kitomis kalbomis: </a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Prašome skaityti <a href="/FAQ#officialtranslations">Klausimus ir Atsakymus</a>, jei norite gauti daugiau informacijos apie oficialiuosius vertimus. </blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_lt.html
+++ b/docroot/legalcode/zero_1.0_lt.html
@@ -77,7 +77,7 @@ Pagal CC0 platinamas Kūrinys gali būti saugomas autorių ir gretutinių teisi�
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Prašome skaityti <a href="/FAQ#officialtranslations">Klausimus ir Atsakymus</a>, jei norite gauti daugiau informacijos apie oficialiuosius vertimus. </blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_lv.html
+++ b/docroot/legalcode/zero_1.0_lv.html
@@ -61,7 +61,25 @@ Darbs, kas ir pieejams saskaņā ar CC0 licenci, var tikt aizsargāts ar autorti
 <li>Attiecinātājs neatbild par citu personu tiesībām, kuras varētu attiekties uz Darbu vai tā lietošanu, izmantošanu, tajā skaitā bez ierobežojuma arī par jebkuras personas Autortiesībām un blakustiesībām saistībā ar Darbu. Turklāt Attiecinātājs neatbild par jebkādu nepieciešamo apstiprinājumu, atļauju vai citu tiesību iegūšanu, kas nepieciešama jebkādai Darba izmantošanai.</li>
 <li>Attiecinātājs izprot un atzīst, ka Creative Commons nav šajā dokumentā iesaistītā puse un tām nav pienākumu vai saistību attiecībā uz šo CC0 vai Darba izmantošanu.</li>
 </ol>
-<blockquote><a id="languages">Citas pieejamās valodas</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Lūdzam iepazīties ar <a href="//wiki.creativecommons.org/FAQ#officialtranslations">BUJ</a> lai uzzinātu papildu informāciju par oficiālajiem tulkojumiem.</blockquote>
+<blockquote><a id="languages">Citas pieejamās valodas</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Lūdzam iepazīties ar <a href="/FAQ#officialtranslations">BUJ</a> lai uzzinātu papildu informāciju par oficiālajiem tulkojumiem.</blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_lv.html
+++ b/docroot/legalcode/zero_1.0_lv.html
@@ -78,7 +78,7 @@ Darbs, kas ir pieejams saskaņā ar CC0 licenci, var tikt aizsargāts ar autorti
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Lūdzam iepazīties ar <a href="/FAQ#officialtranslations">BUJ</a> lai uzzinātu papildu informāciju par oficiālajiem tulkojumiem.</blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_nl.html
+++ b/docroot/legalcode/zero_1.0_nl.html
@@ -188,7 +188,7 @@
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Lees de <a href="/FAQ#officialtranslations">FAQ</a> voor meer informatie over de officiële vertalingen.</blockquote>
       </div>
     </div>

--- a/docroot/legalcode/zero_1.0_nl.html
+++ b/docroot/legalcode/zero_1.0_nl.html
@@ -171,7 +171,25 @@
           en dat op haar geen enkele verplichting of plicht rust met betrekking tot deze CC0 of het
           gebruik van het Werk.</li>
         </ol>
-        <blockquote><a id="languages">Beschikbare aanvullende talen</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Lees de <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> voor meer informatie over de officiële vertalingen.</blockquote>
+        <blockquote><a id="languages">Beschikbare aanvullende talen</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Lees de <a href="/FAQ#officialtranslations">FAQ</a> voor meer informatie over de officiële vertalingen.</blockquote>
       </div>
     </div>
 

--- a/docroot/legalcode/zero_1.0_pl.html
+++ b/docroot/legalcode/zero_1.0_pl.html
@@ -60,7 +60,25 @@ Utwór udostępniany zgodnie z CC0 może podlegać ochronie przez prawa autorski
 <li>Składający Oświadczenie niniejszym wyłącza odpowiedzialność za ewentualne roszczenia osób trzecich, które mogą być związane z Utworem lub jakimkolwiek jego użyciem w tym, m.in. z Prawami Autorskimi i Prawami Pokrewnymi do Utworu przysługującymi jakiejkolwiek osobie. Składający Oświadczenie nie ponosi ponadto odpowiedzialności za uzyskanie wszelkich koniecznych deklaracji zgody, pozwoleń lub innych uprawnień niezbędnych do jakiejkolwiek formy wykorzystania Utworu.</li>
 <li>Składający Oświadczenie rozumie i akceptuje fakt, że organizacja Creative Commons nie jest stroną niniejszego dokumentu i nie ponosi w związku z tym żadnych obowiązków czy zobowiązań.</li>
 </ol>
-<blockquote><a id="languages">Dostępne w innych językach</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Proszę przeczytać <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> w celu uzyskania dalszych informacji na temat oficjalnych tłumaczeń. </blockquote>
+<blockquote><a id="languages">Dostępne w innych językach</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Proszę przeczytać <a href="/FAQ#officialtranslations">FAQ</a> w celu uzyskania dalszych informacji na temat oficjalnych tłumaczeń. </blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_pl.html
+++ b/docroot/legalcode/zero_1.0_pl.html
@@ -77,7 +77,7 @@ Utwór udostępniany zgodnie z CC0 może podlegać ochronie przez prawa autorski
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Proszę przeczytać <a href="/FAQ#officialtranslations">FAQ</a> w celu uzyskania dalszych informacji na temat oficjalnych tłumaczeń. </blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_sv.html
+++ b/docroot/legalcode/zero_1.0_sv.html
@@ -89,7 +89,7 @@ Licensen ska anses gälla från det datum då CC0 applicerades av Upplåtaren p�
 <a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  Vänligen läs <a href="/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.
 </blockquote>
 </div>

--- a/docroot/legalcode/zero_1.0_sv.html
+++ b/docroot/legalcode/zero_1.0_sv.html
@@ -72,7 +72,25 @@ Licensen ska anses gälla från det datum då CC0 applicerades av Upplåtaren p�
 <li>Upplåtaren friskriver sig från ansvar för att klarera rättigheter med andra personer vars rättigheter kan ingå i Verket eller någon form av användning därav, inklusive, utan begränsning, annan persons Upphovsrätt och Relaterade Rättigheter till Verket. Upplåtaren friskriver sig vidare från ansvar för att inhämta varje form av nödvändigt samtycke, tillåtelse eller andra rättigheter som krävs för varje form av användning Verket.</li>
 <li>Upplåtaren är införstådd med och bekräftar att Creative Commons inte är part enligt detta dokument och inte har någon skyldighet eller förpliktelse med hänsyn till denna CC0 eller användning av Verket.</li>
 </ol>
-<blockquote><a id="languages">Övriga tillgängliga språk</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>. Vänligen läs <a href="https://creativecommons.org/faq/#officialtranslations">FAQ</a> för mer information om officiella översättningar.
+<blockquote><a id="languages">Övriga tillgängliga språk</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>.
+<!-- Language Footer End --- DO NOT DELETE -->
+ Vänligen läs <a href="/FAQ#officialtranslations">FAQ</a> för mer information om officiella översättningar.
 </blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_zh-Hans.html
+++ b/docroot/legalcode/zero_1.0_zh-Hans.html
@@ -62,7 +62,25 @@ CC0项下的作品可能受到著作权或者相关权利的保护。著作权�
 <li>声明人没有责任排除他人可能对本作品或者对本作品的任何使用所主张的权利，包括但不限于任何人对本作品享有的著作权及相关权利。声明人也没有责任为使用本作品获取所需的任何同意、许可或其他权利。</li>
 <li>声明人理解并认可CREATIVE COMMONS并非本文件之当事人，对于CC0或本作品的使用也没有任何责任或义务。</li>
 </ol>
-<blockquote><a id="languages">另外的语言版本</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>。请参阅 <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a>获得更多关于正式翻译版本的信息。</blockquote>
+<blockquote><a id="languages">另外的语言版本</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>。
+<!-- Language Footer End --- DO NOT DELETE -->
+请参阅 <a href="/FAQ#officialtranslations">FAQ</a>获得更多关于正式翻译版本的信息。</blockquote>
 </div>
 </div>
 <div id="deed-foot">

--- a/docroot/legalcode/zero_1.0_zh-Hans.html
+++ b/docroot/legalcode/zero_1.0_zh-Hans.html
@@ -79,7 +79,7 @@ CC0项下的作品可能受到著作权或者相关权利的保护。著作权�
 <a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hant">華語</a>。
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
 请参阅 <a href="/FAQ#officialtranslations">FAQ</a>获得更多关于正式翻译版本的信息。</blockquote>
 </div>
 </div>

--- a/docroot/legalcode/zero_1.0_zh-Hant.html
+++ b/docroot/legalcode/zero_1.0_zh-Hant.html
@@ -72,7 +72,7 @@ CREATIVE COMMONS 不是法律事務所，亦不提供法律服務。散布本文
 <a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
 <a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
 <a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>。
-<!-- Language Footer End --- DO NOT DELETE -->
+<!-- Language Footer End - - DO NOT DELETE -->
  請參閱
   <a href="/FAQ#officialtranslations">FAQ</a> 來得到更多正式翻譯版本的資訊。</blockquote>
 </div>

--- a/docroot/legalcode/zero_1.0_zh-Hant.html
+++ b/docroot/legalcode/zero_1.0_zh-Hant.html
@@ -55,8 +55,26 @@ CREATIVE COMMONS 不是法律事務所，亦不提供法律服務。散布本文
 <li>宣告者免責於排除他人可能對本作品或對本作品的任何使用所主張的權利，包含但不限於任何人對本作品的著作權及其相關權利。此外，宣告者亦免責於取得任何必要的同意、允許或其他權利以使用本作品。</li>
 <li>宣告者了解並認知到 Creative Commons 並非本文件之當事人，且對於 CC0 或利用本作品不負任何責任或義務。</li>
 </ol>
-<blockquote><a id="languages">另外的語言版本有</a>: <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.es">Español</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.eu">euskara</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">English</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fr">français</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.it">italiano</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lv">latviski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.pl">polski</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.sv">svenska</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ja">日本語</a>, <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode.ko">한국어</a>. 請參閱
-  <a href="//wiki.creativecommons.org/FAQ#officialtranslations">FAQ</a> 來得到更多正式翻譯版本的資訊。</blockquote>
+<blockquote><a id="languages">另外的語言版本有</a>: 
+<!-- Language Footer Start - DO NOT DELETE -->
+<a href="/publicdomain/zero/1.0/legalcode.el">Ελληνικά</a>,
+<a href="/publicdomain/zero/1.0/legalcode">English</a>,
+<a href="/publicdomain/zero/1.0/legalcode.es">Español</a>,
+<a href="/publicdomain/zero/1.0/legalcode.eu">euskara</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fi">suomeksi</a>,
+<a href="/publicdomain/zero/1.0/legalcode.fr">français</a>,
+<a href="/publicdomain/zero/1.0/legalcode.it">italiano</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ja">日本語</a>,
+<a href="/publicdomain/zero/1.0/legalcode.ko">한국어</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lt">Lietuvių</a>,
+<a href="/publicdomain/zero/1.0/legalcode.lv">latviski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.nl">Nederlands</a>,
+<a href="/publicdomain/zero/1.0/legalcode.pl">polski</a>,
+<a href="/publicdomain/zero/1.0/legalcode.sv">svenska</a>,
+<a href="/publicdomain/zero/1.0/legalcode.zh-Hans">中文</a>。
+<!-- Language Footer End --- DO NOT DELETE -->
+ 請參閱
+  <a href="/FAQ#officialtranslations">FAQ</a> 來得到更多正式翻譯版本的資訊。</blockquote>
 </div>
 </div>
 <div id="deed-foot">


### PR DESCRIPTION
## Description
Update the CC0 language footer
- add HTML comments for easier updates in the future
- sort languages in footer by [RFC 5646](https://tools.ietf.org/html/rfc5646) language tag
- one language link per line for less change churn and easier reading of diffs
- these changes do not impact the legal code ([Legal Code Defined - Creative Commons](https://creativecommons.org/legal-code-defined/)), only the language footer

## Tests
Compare:
| CC0 production | CC0 testing |
| -------------- | ----------- |
| [English (en) old][en-old] | [English (en) new][en-new] |
| [Ελληνικά (el) old][el-old] | [Ελληνικά (el) new][el-new] |
| [Español (es) old][es-old] | [Español (es) new][es-new] |
| [euskara (eu) old][eu-old] | [euskara (eu) new][eu-new] |
| [suomeksi (fi) old][fi-old] | [suomeksi (fi) new][fi-new] |
| [français (fr) old][fr-old] | [français (fr) new][fr-new] |
| [italiano (it) old][it-old] | [italiano (it) new][it-new] |
| [日本語 (ja) old][ja-old] | [日本語 (ja) new][ja-new] |
| [한국어 (ko) old][ko-old] | [한국어 (ko) new][ko-new] |
| [Lietuvių (lt) old][lt-old] | [Lietuvių (lt) new][lt-new] |
| [latviski (lv) old][lv-old] | [latviski (lv) new][lv-new] |
| [Nederlands (nl) old][nl-old] | [Nederlands (nl) new][nl-new] |
| [polski (pl) old][pl-old] | [polski (pl) new][pl-new] |
| [svenska (sv) old][sv-old] | [svenska (sv) new][sv-new] |
| [中文 (zh-Hans) old][zh-Hans-old] | [中文 (zh-Hans) new][zh-Hans-new] |
| [華語 (zh-Hant) old][zh-Hant-old] | [華語 (zh-Hant) new][zh-Hant-new] |

[en-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode#languages
[en-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode#languages
[el-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.el#languages
[el-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.el#languages
[es-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.es#languages
[es-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.es#languages
[eu-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.eu#languages
[eu-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.eu#languages
[fi-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.fi#languages
[fi-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.fi#languages
[fr-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.fr#languages
[fr-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.fr#languages
[it-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.it#languages
[it-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.it#languages
[ja-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.ja#languages
[ja-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.ja#languages
[ko-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.ko#languages
[ko-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.ko#languages
[lt-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.lt#languages
[lt-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.lt#languages
[lv-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.lv#languages
[lv-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.lv#languages
[nl-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.nl#languages
[nl-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.nl#languages
[pl-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.pl#languages
[pl-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.pl#languages
[sv-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.sv#languages
[sv-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.sv#languages
[zh-Hans-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans#languages
[zh-Hans-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hans#languages
[zh-Hant-old]: https://creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant#languages
[zh-Hant-new]: https://.legal.creativecommons.org/publicdomain/zero/1.0/legalcode.zh-Hant#languages

### Notes
- The testing server does not have a FAQ component so the new link to `/faq/#officialtranslations` does not work. On the production server, **it will work**: https://creativecommons.org/faq/#officialtranslations

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
