### PR TITLE
CC 4.0 German translations - add errata text with link

### DIFF
--- a/docroot/legalcode/by-nc-nd_4.0_de.html
+++ b/docroot/legalcode/by-nc-nd_4.0_de.html
@@ -178,7 +178,7 @@ Diese Seite ist in folgenden Sprachen verfügbar:
 
 <div id="deed-disclaimer">
 <div class="summary">
-Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar.
+Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar. <a href="/legal-code-errata/">Ein Fehler</a> in dieser Übersetzung wurde am 26. August 2020 korrigiert.
 </div>
 </div>
 <div class="shaded">

--- a/docroot/legalcode/by-nc-sa_4.0_de.html
+++ b/docroot/legalcode/by-nc-sa_4.0_de.html
@@ -178,7 +178,7 @@ Diese Seite ist in folgenden Sprachen verfügbar:
 
 <div id="deed-disclaimer">
 <div class="summary">
-Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar.
+Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar. <a href="/legal-code-errata/">Ein Fehler</a> in dieser Übersetzung wurde am 26. August 2020 korrigiert.
 </div>
 </div>
 <div class="shaded">

--- a/docroot/legalcode/by-nc_4.0_de.html
+++ b/docroot/legalcode/by-nc_4.0_de.html
@@ -178,7 +178,7 @@ Diese Seite ist in folgenden Sprachen verfügbar:
 
 <div id="deed-disclaimer">
 <div class="summary">
-Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar.
+Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar. <a href="/legal-code-errata/">Ein Fehler</a> in dieser Übersetzung wurde am 26. August 2020 korrigiert.
 </div>
 </div>
 <div class="shaded">

--- a/docroot/legalcode/by-nd_4.0_de.html
+++ b/docroot/legalcode/by-nd_4.0_de.html
@@ -178,7 +178,7 @@ Diese Seite ist in folgenden Sprachen verfügbar:
 
 <div id="deed-disclaimer">
 <div class="summary">
-Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar.
+Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar. <a href="/legal-code-errata/">Ein Fehler</a> in dieser Übersetzung wurde am 26. August 2020 korrigiert.
 </div>
 </div>
 <div class="shaded">

--- a/docroot/legalcode/by-sa_4.0_de.html
+++ b/docroot/legalcode/by-sa_4.0_de.html
@@ -178,7 +178,7 @@ Diese Seite ist in folgenden Sprachen verfügbar:
 
 <div id="deed-disclaimer">
 <div class="summary">
-Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar.
+Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar. <a href="/legal-code-errata/">Ein Fehler</a> in dieser Übersetzung wurde am 26. August 2020 korrigiert.
 </div>
 </div>
 <div class="shaded">

--- a/docroot/legalcode/by_4.0_de.html
+++ b/docroot/legalcode/by_4.0_de.html
@@ -178,7 +178,7 @@ Diese Seite ist in folgenden Sprachen verfügbar:
 
 <div id="deed-disclaimer">
 <div class="summary">
-Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar.
+Offizielle Übersetzungen der Version 4.0 sind in <a href="#languages">anderen Sprachen</a> verfügbar. <a href="/legal-code-errata/">Ein Fehler</a> in dieser Übersetzung wurde am 26. August 2020 korrigiert.
 </div>
 </div>
 <div class="shaded">


### PR DESCRIPTION
## Fixes
Fixes #1147

## Description
CC 4.0 German translations - add errata text with link

Before:
<img width="520" alt="Screen Shot 2020-09-18 at 08 43 32" src="https://user-images.githubusercontent.com/691322/93617659-1c5f4f00-f98b-11ea-9744-9671ff2ed3e9.png">

After:
<img width="520" alt="Screen Shot 2020-09-18 at 08 43 43" src="https://user-images.githubusercontent.com/691322/93617666-1f5a3f80-f98b-11ea-8ed2-979cd76d2707.png">


## Tests

**NOTE**: This testing server does not have a WordPress component so the `/legal-code-errata/` link does not work. However it will work in production ([creativecommons.org/legal-code-errata/](https:///creativecommons.org/legal-code-errata/))

| BY* 4.0 production | BY* 4.0 testing |
| ------------------ | --------------- |
| [by-nc-nd (de) *old*][de-by-nc-nd-old] | [by-nc-nd (de) *new*][de-by-nc-nd-new] |
| [by-nc-sa (de) *old*][de-by-nc-sa-old] | [by-nc-sa (de) *new*][de-by-nc-sa-new] |
| [by-nc (de) *old*][de-by-nc-old] | [by-nc (de) *new*][de-by-nc-new] |
| [by-nd (de) *old*][de-by-nd-old] | [by-nd (de) *new*][de-by-nd-new] |
| [by-sa (de) *old*][de-by-sa-old] | [by-sa (de) *new*][de-by-sa-new] |
| [by (de) *old*][de-by-old] | [by (de) *new*][de-by-new] |
| [by-nc-nd (en) *old*][en-by-nc-nd-old] | [by-nc-nd (en) *new*][en-by-nc-nd-new] |
| [by-nc-sa (en) *old*][en-by-nc-sa-old] | [by-nc-sa (en) *new*][en-by-nc-sa-new] |
| [by-nc (en) *old*][en-by-nc-old] | [by-nc (en) *new*][en-by-nc-new] |
| [by-nd (en) *old*][en-by-nd-old] | [by-nd (en) *new*][en-by-nd-new] |
| [by-sa (en) *old*][en-by-sa-old] | [by-sa (en) *new*][en-by-sa-new] |
| [by (en) *old*][en-by-old] | [by (en) *new*][en-by-new] |

[de-by-nc-nd-old]: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode.de
[de-by-nc-nd-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nc-nd/4.0/legalcode.de
[de-by-nc-sa-old]: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.de
[de-by-nc-sa-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nc-sa/4.0/legalcode.de
[de-by-nc-old]: https://creativecommons.org/licenses/by-nc/4.0/legalcode.de
[de-by-nc-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nc/4.0/legalcode.de
[de-by-nd-old]: https://creativecommons.org/licenses/by-nd/4.0/legalcode.de
[de-by-nd-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nd/4.0/legalcode.de
[de-by-sa-old]: https://creativecommons.org/licenses/by-sa/4.0/legalcode.de
[de-by-sa-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-sa/4.0/legalcode.de
[de-by-old]: https://creativecommons.org/licenses/by/4.0/legalcode.de
[de-by-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by/4.0/legalcode.de
[en-by-nc-nd-old]: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode.en
[en-by-nc-nd-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nc-nd/4.0/legalcode.en
[en-by-nc-sa-old]: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.en
[en-by-nc-sa-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nc-sa/4.0/legalcode.en
[en-by-nc-old]: https://creativecommons.org/licenses/by-nc/4.0/legalcode.en
[en-by-nc-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nc/4.0/legalcode.en
[en-by-nd-old]: https://creativecommons.org/licenses/by-nd/4.0/legalcode.en
[en-by-nd-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-nd/4.0/legalcode.en
[en-by-sa-old]: https://creativecommons.org/licenses/by-sa/4.0/legalcode.en
[en-by-sa-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by-sa/4.0/legalcode.en
[en-by-old]: https://creativecommons.org/licenses/by/4.0/legalcode.en
[en-by-new]: https://cc4-de-legalcode.legal.creativecommons.org/licenses/by/4.0/legalcode.en

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
