### PR TITLE
CC 4.0: Use capital letters for the third level numbering

### DIFF
--- a/docroot/legalcode/by-nc-nd_4.0.txt
+++ b/docroot/legalcode/by-nc-nd_4.0.txt
@@ -145,10 +145,10 @@ Section 2 -- Scope.
           non-sublicensable, non-exclusive, irrevocable license to
           exercise the Licensed Rights in the Licensed Material to:
 
-            a. reproduce and Share the Licensed Material, in whole or
+            A. reproduce and Share the Licensed Material, in whole or
                in part, for NonCommercial purposes only; and
 
-            b. produce and reproduce, but not Share, Adapted Material
+            B. produce and reproduce, but not Share, Adapted Material
                for NonCommercial purposes only.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
@@ -173,13 +173,13 @@ Section 2 -- Scope.
 
        5. Downstream recipients.
 
-            a. Offer from the Licensor -- Licensed Material. Every
+            A. Offer from the Licensor -- Licensed Material. Every
                recipient of the Licensed Material automatically
                receives an offer from the Licensor to exercise the
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. No downstream restrictions. You may not offer or impose
+            B. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -225,7 +225,7 @@ following conditions.
 
        1. If You Share the Licensed Material, You must:
 
-            a. retain the following if it is supplied by the Licensor
+            A. retain the following if it is supplied by the Licensor
                with the Licensed Material:
 
                  i. identification of the creator(s) of the Licensed
@@ -244,10 +244,10 @@ following conditions.
                  v. a URI or hyperlink to the Licensed Material to the
                     extent reasonably practicable;
 
-            b. indicate if You modified the Licensed Material and
+            B. indicate if You modified the Licensed Material and
                retain an indication of any previous modifications; and
 
-            c. indicate the Licensed Material is licensed under this
+            C. indicate the Licensed Material is licensed under this
                Public License, and include the text of, or the URI or
                hyperlink to, this Public License.
 

--- a/docroot/legalcode/by-nc-sa_4.0.txt
+++ b/docroot/legalcode/by-nc-sa_4.0.txt
@@ -157,10 +157,10 @@ Section 2 -- Scope.
           non-sublicensable, non-exclusive, irrevocable license to
           exercise the Licensed Rights in the Licensed Material to:
 
-            a. reproduce and Share the Licensed Material, in whole or
+            A. reproduce and Share the Licensed Material, in whole or
                in part, for NonCommercial purposes only; and
 
-            b. produce, reproduce, and Share Adapted Material for
+            B. produce, reproduce, and Share Adapted Material for
                NonCommercial purposes only.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
@@ -185,19 +185,19 @@ Section 2 -- Scope.
 
        5. Downstream recipients.
 
-            a. Offer from the Licensor -- Licensed Material. Every
+            A. Offer from the Licensor -- Licensed Material. Every
                recipient of the Licensed Material automatically
                receives an offer from the Licensor to exercise the
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. Additional offer from the Licensor -- Adapted Material.
+            B. Additional offer from the Licensor -- Adapted Material.
                Every recipient of Adapted Material from You
                automatically receives an offer from the Licensor to
                exercise the Licensed Rights in the Adapted Material
                under the conditions of the Adapter's License You apply.
 
-            c. No downstream restrictions. You may not offer or impose
+            C. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -244,7 +244,7 @@ following conditions.
        1. If You Share the Licensed Material (including in modified
           form), You must:
 
-            a. retain the following if it is supplied by the Licensor
+            A. retain the following if it is supplied by the Licensor
                with the Licensed Material:
 
                  i. identification of the creator(s) of the Licensed
@@ -263,10 +263,10 @@ following conditions.
                  v. a URI or hyperlink to the Licensed Material to the
                     extent reasonably practicable;
 
-            b. indicate if You modified the Licensed Material and
+            B. indicate if You modified the Licensed Material and
                retain an indication of any previous modifications; and
 
-            c. indicate the Licensed Material is licensed under this
+            C. indicate the Licensed Material is licensed under this
                Public License, and include the text of, or the URI or
                hyperlink to, this Public License.
 

--- a/docroot/legalcode/by-nc_4.0.txt
+++ b/docroot/legalcode/by-nc_4.0.txt
@@ -148,10 +148,10 @@ Section 2 -- Scope.
           non-sublicensable, non-exclusive, irrevocable license to
           exercise the Licensed Rights in the Licensed Material to:
 
-            a. reproduce and Share the Licensed Material, in whole or
+            A. reproduce and Share the Licensed Material, in whole or
                in part, for NonCommercial purposes only; and
 
-            b. produce, reproduce, and Share Adapted Material for
+            B. produce, reproduce, and Share Adapted Material for
                NonCommercial purposes only.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
@@ -176,13 +176,13 @@ Section 2 -- Scope.
 
        5. Downstream recipients.
 
-            a. Offer from the Licensor -- Licensed Material. Every
+            A. Offer from the Licensor -- Licensed Material. Every
                recipient of the Licensed Material automatically
                receives an offer from the Licensor to exercise the
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. No downstream restrictions. You may not offer or impose
+            B. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -229,7 +229,7 @@ following conditions.
        1. If You Share the Licensed Material (including in modified
           form), You must:
 
-            a. retain the following if it is supplied by the Licensor
+            A. retain the following if it is supplied by the Licensor
                with the Licensed Material:
 
                  i. identification of the creator(s) of the Licensed
@@ -248,10 +248,10 @@ following conditions.
                  v. a URI or hyperlink to the Licensed Material to the
                     extent reasonably practicable;
 
-            b. indicate if You modified the Licensed Material and
+            B. indicate if You modified the Licensed Material and
                retain an indication of any previous modifications; and
 
-            c. indicate the Licensed Material is licensed under this
+            C. indicate the Licensed Material is licensed under this
                Public License, and include the text of, or the URI or
                hyperlink to, this Public License.
 

--- a/docroot/legalcode/by-nd_4.0.txt
+++ b/docroot/legalcode/by-nd_4.0.txt
@@ -138,10 +138,10 @@ Section 2 -- Scope.
           non-sublicensable, non-exclusive, irrevocable license to
           exercise the Licensed Rights in the Licensed Material to:
 
-            a. reproduce and Share the Licensed Material, in whole or
+            A. reproduce and Share the Licensed Material, in whole or
                in part; and
 
-            b. produce and reproduce, but not Share, Adapted Material.
+            B. produce and reproduce, but not Share, Adapted Material.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
           Exceptions and Limitations apply to Your use, this Public
@@ -165,13 +165,13 @@ Section 2 -- Scope.
 
        5. Downstream recipients.
 
-            a. Offer from the Licensor -- Licensed Material. Every
+            A. Offer from the Licensor -- Licensed Material. Every
                recipient of the Licensed Material automatically
                receives an offer from the Licensor to exercise the
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. No downstream restrictions. You may not offer or impose
+            B. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -215,7 +215,7 @@ following conditions.
 
        1. If You Share the Licensed Material, You must:
 
-            a. retain the following if it is supplied by the Licensor
+            A. retain the following if it is supplied by the Licensor
                with the Licensed Material:
 
                  i. identification of the creator(s) of the Licensed
@@ -234,10 +234,10 @@ following conditions.
                  v. a URI or hyperlink to the Licensed Material to the
                     extent reasonably practicable;
 
-            b. indicate if You modified the Licensed Material and
+            B. indicate if You modified the Licensed Material and
                retain an indication of any previous modifications; and
 
-            c. indicate the Licensed Material is licensed under this
+            C. indicate the Licensed Material is licensed under this
                Public License, and include the text of, or the URI or
                hyperlink to, this Public License.
 

--- a/docroot/legalcode/by-sa_4.0.txt
+++ b/docroot/legalcode/by-sa_4.0.txt
@@ -149,10 +149,10 @@ Section 2 -- Scope.
           non-sublicensable, non-exclusive, irrevocable license to
           exercise the Licensed Rights in the Licensed Material to:
 
-            a. reproduce and Share the Licensed Material, in whole or
+            A. reproduce and Share the Licensed Material, in whole or
                in part; and
 
-            b. produce, reproduce, and Share Adapted Material.
+            B. produce, reproduce, and Share Adapted Material.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
           Exceptions and Limitations apply to Your use, this Public
@@ -176,19 +176,19 @@ Section 2 -- Scope.
 
        5. Downstream recipients.
 
-            a. Offer from the Licensor -- Licensed Material. Every
+            A. Offer from the Licensor -- Licensed Material. Every
                recipient of the Licensed Material automatically
                receives an offer from the Licensor to exercise the
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. Additional offer from the Licensor -- Adapted Material.
+            B. Additional offer from the Licensor -- Adapted Material.
                Every recipient of Adapted Material from You
                automatically receives an offer from the Licensor to
                exercise the Licensed Rights in the Adapted Material
                under the conditions of the Adapter's License You apply.
 
-            c. No downstream restrictions. You may not offer or impose
+            C. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -233,7 +233,7 @@ following conditions.
        1. If You Share the Licensed Material (including in modified
           form), You must:
 
-            a. retain the following if it is supplied by the Licensor
+            A. retain the following if it is supplied by the Licensor
                with the Licensed Material:
 
                  i. identification of the creator(s) of the Licensed
@@ -252,10 +252,10 @@ following conditions.
                  v. a URI or hyperlink to the Licensed Material to the
                     extent reasonably practicable;
 
-            b. indicate if You modified the Licensed Material and
+            B. indicate if You modified the Licensed Material and
                retain an indication of any previous modifications; and
 
-            c. indicate the Licensed Material is licensed under this
+            C. indicate the Licensed Material is licensed under this
                Public License, and include the text of, or the URI or
                hyperlink to, this Public License.
 

--- a/docroot/legalcode/by_4.0.txt
+++ b/docroot/legalcode/by_4.0.txt
@@ -139,10 +139,10 @@ Section 2 -- Scope.
           non-sublicensable, non-exclusive, irrevocable license to
           exercise the Licensed Rights in the Licensed Material to:
 
-            a. reproduce and Share the Licensed Material, in whole or
+            A. reproduce and Share the Licensed Material, in whole or
                in part; and
 
-            b. produce, reproduce, and Share Adapted Material.
+            B. produce, reproduce, and Share Adapted Material.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
           Exceptions and Limitations apply to Your use, this Public
@@ -166,13 +166,13 @@ Section 2 -- Scope.
 
        5. Downstream recipients.
 
-            a. Offer from the Licensor -- Licensed Material. Every
+            A. Offer from the Licensor -- Licensed Material. Every
                recipient of the Licensed Material automatically
                receives an offer from the Licensor to exercise the
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. No downstream restrictions. You may not offer or impose
+            B. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -217,7 +217,7 @@ following conditions.
        1. If You Share the Licensed Material (including in modified
           form), You must:
 
-            a. retain the following if it is supplied by the Licensor
+            A. retain the following if it is supplied by the Licensor
                with the Licensed Material:
 
                  i. identification of the creator(s) of the Licensed
@@ -236,10 +236,10 @@ following conditions.
                  v. a URI or hyperlink to the Licensed Material to the
                     extent reasonably practicable;
 
-            b. indicate if You modified the Licensed Material and
+            B. indicate if You modified the Licensed Material and
                retain an indication of any previous modifications; and
 
-            c. indicate the Licensed Material is licensed under this
+            C. indicate the Licensed Material is licensed under this
                Public License, and include the text of, or the URI or
                hyperlink to, this Public License.
 


### PR DESCRIPTION
## Fixes
Fixes creativecommons/cc-legal-tools-app#286 by @jodeebrowm 

## Description
Capitalise the letters used in the items of third level enumerations,
e.g. (a)(1)(B) instead of (a)(1)(b).  This is consistent with the HTML
version of the licenses and only affects the labels of the enumeration
not the references inside the text (which are already upper case).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
